### PR TITLE
Make grunt build only for current platform

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,9 +1,13 @@
+var os = require('os');
+
 module.exports = function(grunt) {
+
+  var isWindows = os.platform().indexOf('win') !== -1;
+  var platform = isWindows ? 'win' : 'osx';
 
   grunt.initConfig({
     nodewebkit: {
       options: {
-
         version: 'v0.12.0',
         files: './app/*',
         downloadUrl: 'http://dl.nwjs.io/',
@@ -12,7 +16,7 @@ module.exports = function(grunt) {
         macPlist: {mac_bundle_id: 'messenger.app.com'},
         embed_nw: false,
         keep_nw: true,
-        platforms: ['osx', 'win']
+        platforms: [platform],
       },
       src: './app/**/*' // Your node-webkit app
     },


### PR DESCRIPTION
No point building windows binaries on a mac or vice versa
