### PR TITLE
Make frame show and remove -webkit-app-region: drag for windows builds, ...

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -3,13 +3,15 @@
 <head>
 <style>
 *{margin:0; padding:0;  }
-html,body{width: 100%; height: 100%;}
-body{ -webkit-app-region: drag; }
+html,body{width: 100%; height: 100%; position: absolute; overflow: hidden;}
+body.osx{ -webkit-app-region: drag; }
 #wv1{ width: 100%; height: 100%; }
 </style>
 <script>
+var os = require('os');
 var url = require('url');
 var nw = require('nw.gui');
+
 var win = nw.Window.get();
 var nativeMenuBar = new nw.Menu({ type: "menubar" });
 if (nativeMenuBar.createMacBuiltin) {
@@ -18,6 +20,10 @@ if (nativeMenuBar.createMacBuiltin) {
 win.menu = nativeMenuBar;
 
 window.onload = function() {
+  if (os.platform().indexOf('darwin') !== -1) {
+    document.body.className = "osx";
+  }
+
   document.getElementById('wv1').addEventListener('newwindow', function(e) {
     var urlObj = url.parse(e.targetUrl, true);
     if (urlObj.host.indexOf('facebook') !== -1) {

--- a/app/package.json
+++ b/app/package.json
@@ -7,5 +7,12 @@
     "toolbar": false,
     "width": 900,
     "height": 650
+  },
+  "platformOverrides": {
+    "win": {
+      "window": {
+        "frame": true
+      }
+    }
   }
 }


### PR DESCRIPTION
...fixes #5 

This also fixes the extra scrollbar showing up.

Note that I haven't actually tested this on a mac, only windows.  But I imagine it might work :+1: 
